### PR TITLE
Added SERVER_PORT env

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -2,3 +2,4 @@ IMAP_HOST=yourdomain.com
 IMAP_USER=dmarc
 IMAP_PASS=password
 IMAP_FOLDER=INBOX
+SERVER_PORT=3000

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ const app = express()
 app.use('/dmarc', dmarc)
 app.listen(3000)
 ```
+
+> `SERVER_PORT` has no effect when running as a middleware
+
 Certify yourself that expose environment variables or use `dotenv` module to load it.
 
 `.env` example:
@@ -56,4 +59,5 @@ IMAP_HOST=yourdomain.com
 IMAP_USER=dmarc
 IMAP_PASS=password
 IMAP_FOLDER=INBOX
+SERVER_PORT=3000
 ```

--- a/bin/server
+++ b/bin/server
@@ -20,4 +20,6 @@ app.use(require('../src/app'))
 
 process.on('uncaughtException', errorHandler)
 
-app.listen(3000)
+const server = app.listen(process.env.SERVER_PORT || 3000, () => {
+  console.log(`Server listening on port : ${server.address().port}`)
+})


### PR DESCRIPTION
Proposal for adding the `HTTPX_SERVER_PORT` env variable to change the expressjs server port

Maybe `HTTPX_SERVER_PORT` is not a correct name for the option ?

I also added a message `console.log` that indicates that the server is listening and on wich port.